### PR TITLE
fix: add static export configuration for deployment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  output: 'export',
   trailingSlash: true,
   images: {
     unoptimized: true,


### PR DESCRIPTION
- Add output: 'export' to next.config.ts to generate out/ directory
- Resolves deployment error: directory /workspace/out does not exist
- Enables proper static site generation for hosting platforms